### PR TITLE
total skipped and times details added

### DIFF
--- a/src/mergeToString.js
+++ b/src/mergeToString.js
@@ -20,7 +20,6 @@ module.exports.mergeToString = function (srcStrings, options) {
     errors: 0,
     tests: 0,
     skipped: 0,
-    time: 0
   }
 
   srcStrings.forEach((srcString) => {

--- a/src/mergeToString.js
+++ b/src/mergeToString.js
@@ -28,7 +28,7 @@ module.exports.mergeToString = function (srcStrings, options) {
 
     doc.root().each(
       (xmlBuilder) => {
-        if (xmlBuilder.node.nodeName.toLowerCase() === 'testsuites') {
+        if (xmlBuilder.node.nodeName.toLowerCase() === 'testsuite') {
           for (const attrNode of xmlBuilder.node.attributes) {
             const name = attrNode.name
             if (name in attrs) {

--- a/src/mergeToString.js
+++ b/src/mergeToString.js
@@ -18,7 +18,9 @@ module.exports.mergeToString = function (srcStrings, options) {
   const attrs = {
     failures: 0,
     errors: 0,
-    tests: 0
+    tests: 0,
+    skipped: 0,
+    time: 0
   }
 
   srcStrings.forEach((srcString) => {
@@ -26,7 +28,7 @@ module.exports.mergeToString = function (srcStrings, options) {
 
     doc.root().each(
       (xmlBuilder) => {
-        if (xmlBuilder.node.nodeName.toLowerCase() === 'testsuite') {
+        if (xmlBuilder.node.nodeName.toLowerCase() === 'testsuites') {
           for (const attrNode of xmlBuilder.node.attributes) {
             const name = attrNode.name
             if (name in attrs) {

--- a/test/fixtures/expected/expected-combined-1-3.xml
+++ b/test/fixtures/expected/expected-combined-1-3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<testsuites failures="2" errors="0" tests="6"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
+<testsuites failures="2" errors="0" tests="6" skipped="0" time="0.029"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
         <properties>
             <property name="browser.fullName" value="PhantomJS/1.9.8 Safari/534.34"/>
         </properties>

--- a/test/fixtures/expected/expected-combined-1-3.xml
+++ b/test/fixtures/expected/expected-combined-1-3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<testsuites failures="2" errors="0" tests="6" skipped="0" time="0.029"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
+<testsuites failures="2" errors="0" tests="6" skipped="3" time="0.029"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
         <properties>
             <property name="browser.fullName" value="PhantomJS/1.9.8 Safari/534.34"/>
         </properties>
@@ -11,7 +11,7 @@
         </testcase>
         <system-out><![CDATA[ foo ]]></system-out>
         <system-err/>
-    </testsuite><testsuite name="FAIL" timestamp="2016-01-22T18:25:02" tests="2" failures="1" time="0.001">
+    </testsuite><testsuite name="FAIL" timestamp="2016-01-22T18:25:02" tests="2" skipped="2" failures="1" time="0.001">
         <testcase name="testcase2.1" time="0.001" classname="should fail on client">
         </testcase>
         <testcase name="testcase2.2" time="0" classname="should fail on server">
@@ -21,7 +21,7 @@
     </testsuite><testsuite name="pass1" timestamp="2016-01-22T18:25:02" tests="1" failures="0" time="0.001">
         <testcase name="testcase3.1" time="0.001" classname="should pass 1">
         </testcase>
-    </testsuite><testsuite name="pass2" timestamp="2016-01-22T18:25:02" tests="1" failures="0" time="0.001">
+    </testsuite><testsuite name="pass2" timestamp="2016-01-22T18:25:02" tests="1" skipped="1" failures="0" time="0.001">
         <testcase name="testcase3.2" time="0.001" classname="should pass 2">
         </testcase>
     </testsuite></testsuites>

--- a/test/fixtures/expected/expected-combined-1-3.xml
+++ b/test/fixtures/expected/expected-combined-1-3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<testsuites failures="2" errors="0" tests="6" skipped="3" time="0.029"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
+<testsuites failures="2" errors="0" tests="6" skipped="3"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
         <properties>
             <property name="browser.fullName" value="PhantomJS/1.9.8 Safari/534.34"/>
         </properties>

--- a/test/fixtures/m2.xml
+++ b/test/fixtures/m2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Mocha Tests" time="0.030000000000000006" tests="2" failures="1">
-    <testsuite name="FAIL" timestamp="2016-01-22T18:25:02" tests="2" failures="1" time="0.001">
+<testsuites name="Mocha Tests" time="0.030000000000000006" tests="2" skipped="2" failures="1">
+    <testsuite name="FAIL" timestamp="2016-01-22T18:25:02" tests="2" skipped="2" failures="1" time="0.001">
         <testcase name="testcase2.1" time="0.001" classname="should fail on client">
         </testcase>
         <testcase name="testcase2.2" time="0" classname="should fail on server">

--- a/test/fixtures/m3.xml
+++ b/test/fixtures/m3.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Jasmine Tests" time="0.030000000000000006" tests="2" failures="0">
+<testsuites name="Jasmine Tests" time="0.030000000000000006" tests="2" skipped="1" failures="0">
     <testsuite name="pass1" timestamp="2016-01-22T18:25:02" tests="1" failures="0" time="0.001">
         <testcase name="testcase3.1" time="0.001" classname="should pass 1">
         </testcase>
     </testsuite>
-    <testsuite name="pass2" timestamp="2016-01-22T18:25:02" tests="1" failures="0" time="0.001">
+    <testsuite name="pass2" timestamp="2016-01-22T18:25:02" tests="1" failures="0"  skipped="1" time="0.001">
         <testcase name="testcase3.2" time="0.001" classname="should pass 2">
         </testcase>
     </testsuite>
 </testsuites>
+


### PR DESCRIPTION
Junit report also shows skipped tests and time details for each test suite. The total of skipped tests or time taken are not being populated at the testsuites level. 

all testing tools which generate a combined junit report by default, have the combined detail at the root testsuites level. Added them as part of attributes. 