### PR TITLE
feat: merge testsuite elements with the same name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,15 +6,10 @@ charset = utf-8
 end_of_line = lf
 trim_trailing_whitespace = true
 indent_style = space
+indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.{less,css,html,js,jsx,ts,tsx}]
-indent_size = 4
-
-[*.json]
-indent_size = 2
 
 [*.{js,jsx,ts,tsx}]
 insert_final_newline = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5660,8 +5660,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.4.3",

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -1,0 +1,49 @@
+function sumAggregator(a, b) {
+  return Number(a) + Number(b)
+}
+
+function maxAggregator(a, b) {
+  return Math.max(Number(a), Number(b))
+}
+
+/**
+ * We use https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd as a reference.
+ *
+ * `rollup: true`  - means that attribute will be aggregated for "testsuite"
+ *                         elements and applied to the root "testsuites" element.
+ *
+ * `rollup: false` - means that attribute will be aggregated only for "testsuite" elements.
+ *
+ * Attributes not in this list won't be aggregated.
+ */
+module.exports.KNOWN_ATTRIBUTES = {
+  tests: {
+    aggregator: sumAggregator,
+    rollup: true
+  },
+  failures: {
+    aggregator: sumAggregator,
+    rollup: true
+  },
+  errors: {
+    aggregator: sumAggregator,
+    rollup: true
+  },
+  skipped: {
+    aggregator: sumAggregator,
+    rollup: true
+  },
+  time: {
+    // usually, reports are being generated in a parallel, so using "sum" aggregator here can be wrong.
+    aggregator: maxAggregator,
+    rollup: true
+  },
+  assertions: {
+    aggregator: sumAggregator,
+    rollup: false
+  },
+  warnings: {
+    aggregator: sumAggregator,
+    rollup: false
+  }
+}

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -1,0 +1,25 @@
+function getNodeAttribute(node, name) {
+  for (const attrNode of node.attributes) {
+    if (attrNode.name === name) {
+      return attrNode.value
+    }
+  }
+}
+
+function isTestSuiteNode(node) {
+  return node.nodeName.toLowerCase() === 'testsuite'
+}
+
+function findTestSuiteByName(builder, suiteName) {
+  return builder.find(
+    ({ node }) => isTestSuiteNode(node) && suiteName === getNodeAttribute(node, 'name'),
+    false,
+    false
+  )
+}
+
+module.exports = {
+  findTestSuiteByName,
+  isTestSuiteNode,
+  getNodeAttribute
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -36,7 +36,12 @@ async function readableToString(readable) {
   return result
 }
 
+function isNumeric(str) {
+  return !isNaN(str) && !isNaN(parseFloat(str))
+}
+
 module.exports = {
   normalizeArgs,
-  readableToString
+  readableToString,
+  isNumeric
 }

--- a/test/fixtures/expected/expected-combined-1-3.xml
+++ b/test/fixtures/expected/expected-combined-1-3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<testsuites failures="2" errors="0" tests="6" skipped="3"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
+<testsuites failures="2" errors="0" tests="6" skipped="3" time="0.026"><testsuite name="PhantomJS 1.9.8" package="" timestamp="2016-01-22T18:25:08" id="0" hostname="MacBook-Pro.local" tests="2" errors="0" failures="1" time="0.026">
         <properties>
             <property name="browser.fullName" value="PhantomJS/1.9.8 Safari/534.34"/>
         </properties>

--- a/test/fixtures/testsuite-merging/1/expected.xml
+++ b/test/fixtures/testsuite-merging/1/expected.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="0" errors="0" skipped="0" time="131.521648">
+  <testsuite name="A" tests="2" assertions="16" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="2" assertions="16" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="2" assertions="16" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+        <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/1/file1.xml
+++ b/test/fixtures/testsuite-merging/1/file1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/1/file2.xml
+++ b/test/fixtures/testsuite-merging/1/file2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/2/expected.xml
+++ b/test/fixtures/testsuite-merging/2/expected.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="0" errors="0" skipped="0" time="3333">
+  <testsuite name="A" tests="3" assertions="16" errors="0" warnings="0" failures="0" skipped="0" time="3333">
+    <testsuite name="B" tests="2" assertions="16" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="2" assertions="16" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+        <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+    <testcase name="test3" class="SimpleScaleTest1" classname="SimpleScaleTest1" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="3333">
+      <system-out>ffmpeg</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/2/file1.xml
+++ b/test/fixtures/testsuite-merging/2/file1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/2/file2.xml
+++ b/test/fixtures/testsuite-merging/2/file2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="2" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="3333">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+    <testcase name="test3" class="SimpleScaleTest1" classname="SimpleScaleTest1" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="3333">
+      <system-out>ffmpeg</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/3/expected.xml
+++ b/test/fixtures/testsuite-merging/3/expected.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="0" errors="0" skipped="0" time="131.521648">
+  <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+  <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers</system-out>
+      </testcase>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/3/file1.xml
+++ b/test/fixtures/testsuite-merging/3/file1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/3/file2.xml
+++ b/test/fixtures/testsuite-merging/3/file2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/4/expected.xml
+++ b/test/fixtures/testsuite-merging/4/expected.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" errors="0" time="2">
+    <testsuite name="A" tests="2" errors="0" assertions="8" time="2">
+        <testcase name="test1" time="1" />
+        <testcase name="test2" assertions="8" time="2" />
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/4/file1.xml
+++ b/test/fixtures/testsuite-merging/4/file1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="1" errors="0" time="2">
+    <testcase name="test1" time="1" />
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/4/file2.xml
+++ b/test/fixtures/testsuite-merging/4/file2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="A" tests="1" assertions="8" errors="0" time="2">
+        <testcase name="test2" assertions="8" time="2" />
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/5/expected.xml
+++ b/test/fixtures/testsuite-merging/5/expected.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" errors="0" time="6">
+    <testsuite name="" tests="2" errors="0" time="6">
+        <testcase name="testA-1" time="2"/>
+        <testsuite name="subA" tests="4" errors="0" time="3">
+            <testcase name="test-subA-1" time="1"/>
+            <testcase name="test-subA-2" time="3"/>
+            <testcase name="test-subA-3" time="3"/>
+            <testcase name="test-subA-4" time="2"/>
+        </testsuite>
+        <testcase name="testA-2" time="2"/>
+        <testcase name="testA-3" time="2"/>
+        <testcase name="testA-4" time="6"/>
+    </testsuite>
+    <testsuite name="B" tests="1" errors="0" time="3">
+        <testcase name="testB-1" time="2"/>
+        <testsuite name="subA" tests="2" errors="0" time="3">
+            <testcase name="test-B-subA-1" time="1"/>
+            <testcase name="test-B-subA-2" time="3"/>
+        </testsuite>
+        <testcase name="testB-2" time="2"/>
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/5/file1.xml
+++ b/test/fixtures/testsuite-merging/5/file1.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="" tests="1" errors="0" time="3">
+    <testcase name="testA-1" time="2" />
+    <testsuite name="subA" tests="2" errors="0" time="3">
+      <testcase name="test-subA-1" time="1" />
+      <testcase name="test-subA-2" time="3" />
+    </testsuite>
+    <testcase name="testA-2" time="2" />
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/5/file2.xml
+++ b/test/fixtures/testsuite-merging/5/file2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="B" tests="1" errors="0" time="3">
+        <testcase name="testB-1" time="2" />
+        <testsuite name="subA" tests="2" errors="0" time="3">
+            <testcase name="test-B-subA-1" time="1" />
+            <testcase name="test-B-subA-2" time="3" />
+        </testsuite>
+        <testcase name="testB-2" time="2" />
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/5/file3.xml
+++ b/test/fixtures/testsuite-merging/5/file3.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="" tests="1" errors="0" time="6">
+        <testcase name="testA-3" time="2" />
+        <testsuite name="subA" tests="2" errors="0" time="3">
+            <testcase name="test-subA-3" time="3" />
+            <testcase name="test-subA-4" time="2" />
+        </testsuite>
+        <testcase name="testA-4" time="6" />
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
This fixes #226 and fixes #227.

This is a semver-major.
Previously we're basically concatenating contents of different input files. That worked wrong for nested testsuite elements.
In this commit we traverse report XML and merge testsuite elements based on their names. It is the change in tool behavior, that's why it can be breaking for some use cases.