### PR TITLE
Add option to aggregate time using sum instead of max

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,22 @@ Signature:
 type MergeFilesOptions = {
     onFileMatched? (matchInfo: {
         filePath: string
-    }) => void
+    }) => void;
+
+    sumTime: boolean;
 }
 ```
 
 #### `onFileMatched`
 
 [`mergeFiles`](#mergefiles) calls function specified by the `onFileMatched` option once for each file matched by `srcFilePaths`, right before file processing begins.
+
+#### `sumTime`
+
+When `true`, the `time` attribute of the top-level `testsuites` element will be aggregated using `sum` instead of `max`.
+This sums the run times from all testsuites and represents the time it took to perform all tests, _without_ accounting for parallelization. The actual time it took to perform all tests may be shorter when testsuites ran in parallel.
+
+When `false` (default), the `time` attribute of the top-level `testsuites` element contains the longest time a test testsuite took to run which is probably closer to the real execution time in case all testsuites ran in parallel.
 
 ## mergeStreams
 
@@ -152,25 +161,25 @@ Signature:
 mergeStreams(
     destStream: WritableStream,
     srcStreams: ReadableStream[],
-    options?: {}
-) => Promise<void>
+    options?: MergeStreamsOptions
+) => Promise<void>;
 
 mergeStreams(
     destStream: WritableStream,
     srcStreams: ReadableStream[],
-    options: {},
-    cb: (err?: Error) => void
-) => void
+    options: MergeStreamsOptions,
+    cb: (err?: Error) => void;
+) => void;
 ```
 
 Reads multiple streams, merges their contents and write into the given stream.
 
-| Param      | Type                               | Description                                                                                        |
-| ---------- | ---------------------------------- | -------------------------------------------------------------------------------------------------- |
-| destStream | <code>WritableStream</code>        | A stream which will be used to write the merge result.                                             |
-| srcStreams | <code>ReadableStream[]</code>      | Streams which will be used to read data from.                                                      |
-| [options]  | <code>object</code>                | Merge options. Currently unused.                                                                   |
-| [cb]       | <code>(err?: Error) => void</code> | Callback function which will be called at completion. Will receive error as first argument if any. |
+| Param      | Type                                                     | Description                                                                                        |
+| ---------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| destStream | <code>WritableStream</code>                              | A stream which will be used to write the merge result.                                             |
+| srcStreams | <code>ReadableStream[]</code>                            | Streams which will be used to read data from.                                                      |
+| [options]  | <code>[MergeStreamsOptions](#mergestreamsoptions)</code> | Merge options.                                                                                     |
+| [cb]       | <code>(err?: Error) => void</code>                       | Callback function which will be called at completion. Will receive error as first argument if any. |
 
 Last argument - `cb` is a Node.js style callback function. If callback function is not passed, function will return a promise. That is, all the following variants will work:
 
@@ -188,6 +197,25 @@ await mergeStreams(destStream, srcStreams, {})
 await mergeStreams(destStream, srcStreams)
 ```
 
+### `MergeStreamsOptions`
+
+These are the options accepted by [`mergeStreams`](#mergestreams).
+
+Signature:
+
+```typescript
+type MergeStreamsOptions = {
+  sumTime: boolean
+}
+```
+
+#### `sumTime`
+
+When `true`, the `time` attribute of the top-level `testsuites` element will be aggregated using `sum` instead of `max`.
+This sums the run times from all testsuites and represents the time it took to perform all tests, _without_ accounting for parallelization. The actual time it took to perform all tests may be shorter when testsuites ran in parallel.
+
+When `false` (default), the `time` attribute of the top-level `testsuites` element contains the longest time a test testsuite took to run which is probably closer to the real execution time in case all testsuites ran in parallel.
+
 ## mergeToString
 
 Signature:
@@ -195,16 +223,35 @@ Signature:
 ```typescript
 mergeToString(
     srcStrings: string[],
-    options?: {}
+    options?: MergeToStringOptions
 ) => string
 ```
 
 Merges given XML strings and returns the result.
 
-| Param      | Type                  | Description                         |
-| ---------- | --------------------- | ----------------------------------- |
-| srcStrings | <code>string[]</code> | Array of strings to merge together. |
-| [options]  | <code>object</code>   | Merge options. Currently unused.    |
+| Param      | Type                                                       | Description                         |
+| ---------- | ---------------------------------------------------------- | ----------------------------------- |
+| srcStrings | <code>string[]</code>                                      | Array of strings to merge together. |
+| [options]  | <code>[MergeToStringOptions](#mergetostringoptions)</code> | Merge options.                      |
+
+### `MergeToStringOptions`
+
+These are the options accepted by [`mergeToString`](#mergetostring).
+
+Signature:
+
+```typescript
+type MergeToStringOptions = {
+  sumTime: boolean
+}
+```
+
+#### `sumTime`
+
+When `true`, the `time` attribute of the top-level `testsuites` element will be aggregated using `sum` instead of `max`.
+This sums the run times from all testsuites and represents the time it took to perform all tests, _without_ accounting for parallelization. The actual time it took to perform all tests may be shorter when testsuites ran in parallel.
+
+When `false` (default), the `time` attribute of the top-level `testsuites` element contains the longest time a test testsuite took to run which is probably closer to the real execution time in case all testsuites ran in parallel.
 
 ## JUnit XML Format
 

--- a/cli.js
+++ b/cli.js
@@ -15,16 +15,18 @@ function getProgram() {
       'Example (glob patterns to match input files):\n  jrm ./results/combined.xml "./results/units/*.xml" "./results/e2e/*.xml"'
   )
   program.arguments('<destination> <sources...>')
+  program.option('-t, --sum-time', 'Aggregate testsuite time with sum instead of max', false)
   return program
 }
 
 const program = getProgram()
-program.action(async function (destination, sources) {
+program.action(async function (destination, sources, options) {
   const destFilePath = destination
   const srcFilePathsOrGlobPatterns = sources
 
   let processedFileCount = 0
   await mergeFiles(destFilePath, srcFilePathsOrGlobPatterns, {
+    sumTime: options.sumTime,
     onFileMatched: () => {
       ++processedFileCount
     }

--- a/src/aggregators.js
+++ b/src/aggregators.js
@@ -1,0 +1,32 @@
+/**
+ * Aggregate using sum.
+ *
+ * @example sumAggregator(3, 9) == 12
+ *
+ * @param a
+ * @param b
+ *
+ * @returns {number}
+ */
+function sumAggregator(a, b) {
+  return Number(a) + Number(b)
+}
+
+/**
+ * Aggregate using Math.max.
+ *
+ * @example maxAggregator(3, 9) == 9
+ *
+ * @param a
+ * @param b
+ *
+ * @returns {number}
+ */
+function maxAggregator(a, b) {
+  return Math.max(Number(a), Number(b))
+}
+
+module.exports = {
+  sumAggregator,
+  maxAggregator
+}

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -16,7 +16,7 @@ function maxAggregator(a, b) {
  *
  * Attributes not in this list won't be aggregated.
  */
-module.exports.KNOWN_ATTRIBUTES = {
+const KNOWN_ATTRIBUTES = {
   tests: {
     aggregator: sumAggregator,
     rollup: true
@@ -46,4 +46,10 @@ module.exports.KNOWN_ATTRIBUTES = {
     aggregator: sumAggregator,
     rollup: false
   }
+}
+
+module.exports = {
+  sumAggregator,
+  maxAggregator,
+  KNOWN_ATTRIBUTES
 }

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -1,10 +1,4 @@
-function sumAggregator(a, b) {
-  return Number(a) + Number(b)
-}
-
-function maxAggregator(a, b) {
-  return Math.max(Number(a), Number(b))
-}
+const { sumAggregator, maxAggregator } = require('./aggregators')
 
 /**
  * We use https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd as a reference.
@@ -16,7 +10,7 @@ function maxAggregator(a, b) {
  *
  * Attributes not in this list won't be aggregated.
  */
-const KNOWN_ATTRIBUTES = {
+module.exports.KNOWN_ATTRIBUTES = {
   tests: {
     aggregator: sumAggregator,
     rollup: true
@@ -46,10 +40,4 @@ const KNOWN_ATTRIBUTES = {
     aggregator: sumAggregator,
     rollup: false
   }
-}
-
-module.exports = {
-  sumAggregator,
-  maxAggregator,
-  KNOWN_ATTRIBUTES
 }

--- a/src/mergeFiles.js
+++ b/src/mergeFiles.js
@@ -13,6 +13,7 @@ const { mergeToString } = require('./mergeToString.js')
  *
  * @typedef {Object} MergeFilesOptions
  * @property {MergeFilesCallback} [onFileMatched]  A callback function which will be called for the each match
+ * @property {boolean} sumTime  Aggregate testsuite time with sum instead of max
  *
  * @callback TMergeFilesCompletionCallback
  * @param {Error} [err]  Error if any
@@ -29,7 +30,7 @@ const { mergeToString } = require('./mergeToString.js')
  * @callback MergeFilesPromiseStyle Reads multiple files, merges their contents and write into the given file.
  * @param {String} destFilePath   Where the output should be stored. Denotes a path to file. If file already exists, it will be overwritten.
  * @param {String[]} srcFilePathsOrGlobPatterns   Paths to the files which should be merged or glob patterns to find them.
- * @param {MergeFilesOptions} [options]   Merge options. Currently unused.
+ * @param {MergeFilesOptions} [options]   Merge options.
  * @return {Promise<void>}
  *
  * @typedef {MergeFilesCallbackStyle & MergeFilesPromiseStyle} MergeFilesFn
@@ -54,7 +55,9 @@ module.exports.mergeFiles = function (destFilePath, srcFilePathsOrGlobPatterns, 
         srcStrings.push(content)
       }
 
-      const mergedContent = await mergeToString(srcStrings, {})
+      const mergedContent = await mergeToString(srcStrings, {
+        sumTime: normalizedOptions?.sumTime ?? false
+      })
       await fs.promises.writeFile(destFilePath, mergedContent, 'utf8')
 
       callback()

--- a/src/mergeStreams.js
+++ b/src/mergeStreams.js
@@ -2,7 +2,8 @@ const { normalizeArgs, readableToString } = require('./helpers.js')
 const { mergeToString } = require('./mergeToString.js')
 
 /**
- * @typedef {{}} MergeStreamsOptions
+ * @typedef {Object} MergeStreamsOptions
+ * @property {boolean} sumTime  Aggregate testsuite time with sum instead of max
  *
  * @callback TMergeStreamsCallback
  * @param {Error} [err]  Error if any
@@ -12,14 +13,14 @@ const { mergeToString } = require('./mergeToString.js')
  * @callback MergeStreamsCallbackStyle
  * @param {import('stream').Writable} destStream   A stream which will be used to write the merge result.
  * @param {import('stream').Readable[]} srcStreams   Streams which will be used to read data from.
- * @param {MergeStreamsOptions} options   Merge options. Currently unused.
+ * @param {MergeStreamsOptions} options   Merge options.
  * @param {TMergeStreamsCallback} cb   Callback function which will be called at completion. Will receive error as first argument if any.
  * @return {void}
  *
  * @callback MergeStreamsPromiseStyle
  * @param {import('stream').Writable} destStream   A stream which will be used to write the merge result.
  * @param {import('stream').Readable[]} srcStreams   Streams which will be used to read data from.
- * @param {MergeStreamsOptions} [options]   Merge options. Currently unused.
+ * @param {MergeStreamsOptions} [options]   Merge options.
  * @return {Promise<void>}
  *
  * @typedef {MergeStreamsCallbackStyle & MergeStreamsPromiseStyle} MergeStreamsFn
@@ -31,7 +32,9 @@ module.exports.mergeStreams = function (destStream, srcStreams, options, cb) {
 
   Promise.all(srcStreams.map(readableToString))
     .then(async (srcStrings) => {
-      let destString = await mergeToString(srcStrings, options)
+      let destString = await mergeToString(srcStrings, {
+        sumTime: normalizedOptions?.sumTime ?? false
+      })
       destStream.on('error', callback)
       destStream.write(destString, 'utf8', callback)
     })

--- a/src/mergeToString.js
+++ b/src/mergeToString.js
@@ -9,14 +9,14 @@ const {
 } = require('./domHelpers.js')
 
 /**
- * @typedef {Object} MergeStringsOptions
+ * @typedef {Object} MergeToStringOptions
  * @property {boolean} sumTime  Aggregate testsuite time with sum instead of max
  */
 
 /**
  * Merges contents of given XML strings and returns resulting XML string.
  * @param {String[]} srcStrings   Array of strings to merge together.
- * @param {MergeStringsOptions} [options]   Merge options.
+ * @param {MergeToStringOptions} [options]   Merge options.
  * @return {Promise<String>}
  */
 module.exports.mergeToString = async function (srcStrings, options) {

--- a/src/mergeToString.js
+++ b/src/mergeToString.js
@@ -1,4 +1,5 @@
-const { KNOWN_ATTRIBUTES, sumAggregator } = require('./attributes.js')
+const { KNOWN_ATTRIBUTES } = require('./attributes.js')
+const { sumAggregator } = require('./aggregators')
 const { isNumeric } = require('./helpers.js')
 const {
   getNodeAttribute,

--- a/src/mergeToString.js
+++ b/src/mergeToString.js
@@ -1,4 +1,4 @@
-const { KNOWN_ATTRIBUTES } = require('./attributes.js')
+const { KNOWN_ATTRIBUTES, sumAggregator } = require('./attributes.js')
 const { isNumeric } = require('./helpers.js')
 const {
   getNodeAttribute,
@@ -8,13 +8,14 @@ const {
 } = require('./domHelpers.js')
 
 /**
- * @typedef {{}} MergeStringsOptions
+ * @typedef {Object} MergeStringsOptions
+ * @property {boolean} sumTime  Aggregate testsuite time with sum instead of max
  */
 
 /**
  * Merges contents of given XML strings and returns resulting XML string.
  * @param {String[]} srcStrings   Array of strings to merge together.
- * @param {MergeStringsOptions} [options]   Merge options. Currently unused.
+ * @param {MergeStringsOptions} [options]   Merge options.
  * @return {Promise<String>}
  */
 module.exports.mergeToString = async function (srcStrings, options) {
@@ -113,7 +114,10 @@ module.exports.mergeToString = async function (srcStrings, options) {
         for (let attrName of attributeNames) {
           const attrValue = getNodeAttribute(node, attrName)
           if (attrValue !== undefined && isNumeric(attrValue)) {
-            const { aggregator } = KNOWN_ATTRIBUTES[attrName]
+            const aggregator =
+              attrName === 'time' && options?.sumTime === true
+                ? sumAggregator
+                : KNOWN_ATTRIBUTES[attrName].aggregator
             attributes[attrName] = aggregator(attributes[attrName] || 0, attrValue)
           }
         }

--- a/test/e2e.spec.mjs
+++ b/test/e2e.spec.mjs
@@ -19,7 +19,10 @@ describe('e2e', function () {
     }
   })
 
-  async function assertOutput() {
+  /**
+   * @param {{sumTime: boolean}} options
+   */
+  async function assertOutput(options = {}) {
     const contents = await fsPromises.readFile(fixturePaths.output, { encoding: 'utf8' })
     const doc = create(contents).root()
     expect(doc.node.childNodes).toHaveLength(4)
@@ -28,14 +31,15 @@ describe('e2e', function () {
     const foundAttrs = {}
     for (const attrNode of doc.node.attributes) {
       const name = attrNode.name
-      if (['tests', 'errors', 'failures'].includes(name)) {
+      if (['tests', 'errors', 'failures', 'time'].includes(name)) {
         foundAttrs[name] = attrNode.value
       }
     }
     expect(foundAttrs).toEqual({
       tests: '6',
       errors: '0',
-      failures: '2'
+      failures: '2',
+      time: options.sumTime ? '0.029' : '0.026'
     })
   }
 
@@ -43,7 +47,7 @@ describe('e2e', function () {
     afterEach(async () => {
       await fsPromises.unlink(fixturePaths.output)
     })
-    
+
     it('merges xml reports (options passed)', async () => {
       await mergeFiles(fixturePaths.output, fixturePaths.inputs, {})
       await assertOutput()
@@ -196,6 +200,23 @@ describe('e2e', function () {
         expect(create(actualContents).toObject()).toEqual(create(expectedContents).toObject())
       }
     )
+
+    it.each([
+      { fixtureFolder: path.join('testsuite-merging', '6') },
+      { fixtureFolder: path.join('testsuite-merging', '7') }
+    ])(
+      'merges xml reports with sum time ("$fixtureFolder/file*.xml" -> "$fixtureFolder/expected.xml")',
+      async ({ fixtureFolder }) => {
+        const expectedOutputPath = path.join(__dirname, 'fixtures', fixtureFolder, 'expected.xml')
+        fixturePaths.inputs = [path.join(__dirname, 'fixtures', fixtureFolder, 'file*.xml')]
+        await mergeFiles(fixturePaths.output, fixturePaths.inputs, {
+          sumTime: true
+        })
+        const actualContents = await fsPromises.readFile(fixturePaths.output, { encoding: 'utf8' })
+        const expectedContents = await fsPromises.readFile(expectedOutputPath, { encoding: 'utf8' })
+        expect(create(actualContents).toObject()).toEqual(create(expectedContents).toObject())
+      }
+    )
   })
 
   describe('mergeStreams', function () {
@@ -332,6 +353,25 @@ describe('e2e', function () {
       expect(stdout).toMatch('3 files processed')
       expect(stdout).not.toMatch('Provided input file patterns did not matched any file.')
       await assertOutput()
+    })
+
+    it('merges xml reports with sum time', async () => {
+      const { exec } = await import('node:child_process')
+      const stdout = await new Promise((resolve, reject) => {
+        exec(
+          'node ./cli.js --sum-time ./test/output/actual-combined-1-3.xml "./test/**/m1.xml" "./test/**/m?.xml"',
+          function (error, stdout, stderr) {
+            if (error) {
+              reject(error)
+            } else {
+              resolve(stdout)
+            }
+          }
+        )
+      })
+      expect(stdout).toMatch('3 files processed')
+      expect(stdout).not.toMatch('Provided input file patterns did not matched any file.')
+      await assertOutput({ sumTime: true })
     })
 
     it('provides meaningful message if no input files can be found', async () => {

--- a/test/fixtures/testsuite-merging/6/expected.xml
+++ b/test/fixtures/testsuite-merging/6/expected.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="0" errors="0" skipped="0" time="263.043296">
+  <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+  <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers</system-out>
+      </testcase>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/6/file1.xml
+++ b/test/fixtures/testsuite-merging/6/file1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
+</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/6/file2.xml
+++ b/test/fixtures/testsuite-merging/6/file2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+      <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
+        <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
+          <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers</system-out>
+        </testcase>
+      </testsuite>
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/7/expected.xml
+++ b/test/fixtures/testsuite-merging/7/expected.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" errors="0" time="9">
+    <testsuite name="" tests="2" errors="0" time="6">
+        <testcase name="testA-1" time="2"/>
+        <testsuite name="subA" tests="4" errors="0" time="3">
+            <testcase name="test-subA-1" time="1"/>
+            <testcase name="test-subA-2" time="3"/>
+            <testcase name="test-subA-3" time="3"/>
+            <testcase name="test-subA-4" time="2"/>
+        </testsuite>
+        <testcase name="testA-2" time="2"/>
+        <testcase name="testA-3" time="2"/>
+        <testcase name="testA-4" time="6"/>
+    </testsuite>
+    <testsuite name="B" tests="1" errors="0" time="3">
+        <testcase name="testB-1" time="2"/>
+        <testsuite name="subA" tests="2" errors="0" time="3">
+            <testcase name="test-B-subA-1" time="1"/>
+            <testcase name="test-B-subA-2" time="3"/>
+        </testsuite>
+        <testcase name="testB-2" time="2"/>
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/7/file1.xml
+++ b/test/fixtures/testsuite-merging/7/file1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="" tests="1" errors="0" time="3">
+  <testcase name="testA-1" time="2" />
+  <testsuite name="subA" tests="2" errors="0" time="3">
+    <testcase name="test-subA-1" time="1" />
+    <testcase name="test-subA-2" time="3" />
+  </testsuite>
+  <testcase name="testA-2" time="2" />
+</testsuite>

--- a/test/fixtures/testsuite-merging/7/file2.xml
+++ b/test/fixtures/testsuite-merging/7/file2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="B" tests="1" errors="0" time="3">
+        <testcase name="testB-1" time="2" />
+        <testsuite name="subA" tests="2" errors="0" time="3">
+            <testcase name="test-B-subA-1" time="1" />
+            <testcase name="test-B-subA-2" time="3" />
+        </testsuite>
+        <testcase name="testB-2" time="2" />
+    </testsuite>
+</testsuites>

--- a/test/fixtures/testsuite-merging/7/file3.xml
+++ b/test/fixtures/testsuite-merging/7/file3.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="" tests="1" errors="0" time="6">
+        <testcase name="testA-3" time="2" />
+        <testsuite name="subA" tests="2" errors="0" time="3">
+            <testcase name="test-subA-3" time="3" />
+            <testcase name="test-subA-4" time="2" />
+        </testsuite>
+        <testcase name="testA-4" time="6" />
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
As discussed in #450, this PR adds a `sumTime` option to the merge functions and `-t, --sum-time` option to the CLI. Enabling this function will use the sum aggregator for the time attribute of `testsuites` elements.

By default this option is disabled to maintain backwards compatibility.

### Example
Notice the time of the top `testsuites` element has changed to be the sum of the directly underlying `testsuite` elements.

```patch
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" failures="0" errors="0" skipped="0" time="131.521648">
+<testsuites tests="2" failures="0" errors="0" skipped="0" time="263.043296">
   <testsuite name="A" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
     <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
       <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
         <testcase name="test1" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
           <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
   built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
 </system-out>
         </testcase>
       </testsuite>
     </testsuite>
   </testsuite>
   <testsuite name="B" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
     <testsuite name="C" file="/opt/video-converter/tests/SimpleScaleTest.php" tests="1" assertions="8" errors="0" warnings="0" failures="0" skipped="0" time="131.521648">
       <testcase name="test2" class="SimpleScaleTest" classname="SimpleScaleTest" file="/opt/video-converter/tests/SimpleScaleTest.php" line="27" assertions="8" time="131.521648">
           <system-out>ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers</system-out>
       </testcase>
     </testsuite>
   </testsuite>
 </testsuites>
```